### PR TITLE
[Fix] 탄환 크래시 해결 #22

### DIFF
--- a/Source/Splatoon/Bullets/PaintDecal.cpp
+++ b/Source/Splatoon/Bullets/PaintDecal.cpp
@@ -1,8 +1,7 @@
 #include "PaintDecal.h"
+#include "PaintDecalManager.h"
 #include "Components/DecalComponent.h"
 #include "Materials/MaterialInterface.h"
-
-TArray<APaintDecal*> APaintDecal::DecalList;
 
 APaintDecal::APaintDecal()
 {
@@ -16,9 +15,7 @@ APaintDecal::APaintDecal()
 	{
 		DecalMaterial = PaintDecalMaterial.Object;
 	}
-
 	DecalSize = FVector(1.f);
-	MaxDecal = 50;
 }
 
 void APaintDecal::BeginPlay()
@@ -31,7 +28,11 @@ void APaintDecal::BeginPlay()
 		DecalComp->SetWorldScale3D(DecalSize);
 	}
 
-	ManageDecal(this);
+	UPaintDecalManager* Manager = UPaintDecalManager::GetInstance(GetWorld());
+	if (Manager)
+	{
+		Manager->AddDecalList(this);
+	}
 }
 
 void APaintDecal::SpawnPaintDecal(UWorld* World, const FVector& Location, const FRotator& Rotator)
@@ -39,24 +40,7 @@ void APaintDecal::SpawnPaintDecal(UWorld* World, const FVector& Location, const 
 	if (!World) return;
 
 	FActorSpawnParameters SpawnParms;
-	World->SpawnActor<APaintDecal>(APaintDecal::StaticClass(), Location, Rotator, SpawnParms);
-}
-
-void APaintDecal::ManageDecal(APaintDecal* NewDecal)
-{
-	if (!NewDecal) return;
-
-	DecalList.Add(NewDecal);
-
-	// 레벨에 스폰된 데칼 개수가 최대치를 넘어가면 가장 오래된 데칼 삭제
-	if (DecalList.Num() > MaxDecal)
-	{
-		if (DecalList[0])
-		{
-			DecalList[0]->Destroy();
-		}
-		DecalList.RemoveAt(0);
-	}
+	APaintDecal* NewDecal = World->SpawnActor<APaintDecal>(APaintDecal::StaticClass(), Location, Rotator, SpawnParms);
 }
 
 

--- a/Source/Splatoon/Bullets/PaintDecal.h
+++ b/Source/Splatoon/Bullets/PaintDecal.h
@@ -6,6 +6,7 @@
 
 class UDecalComponent;
 class UMaterialInterface;
+class UPaintDecalManager;
 
 UCLASS()
 class SPLATOON_API APaintDecal : public AActor
@@ -13,9 +14,9 @@ class SPLATOON_API APaintDecal : public AActor
 	GENERATED_BODY()
 	
 public:	
-	// Sets default values for this actor's properties
 	APaintDecal();
 
+public:
 	static void SpawnPaintDecal(UWorld* World, const FVector& Location, const FRotator& Rotator);
 
 protected:
@@ -25,13 +26,6 @@ protected:
 	UMaterialInterface* DecalMaterial;
 	UPROPERTY(EditDefaultsOnly, Category = "Bullet|Paint")
 	FVector DecalSize;
-	UPROPERTY(EditDefaultsOnly, Category = "Bullet|Paint")
-	int32 MaxDecal;
 
 	virtual void BeginPlay() override;
-
-private:
-	static TArray<APaintDecal*> DecalList;
-
-	void ManageDecal(APaintDecal* NewDecal);
 };

--- a/Source/Splatoon/Bullets/PaintDecalManager.cpp
+++ b/Source/Splatoon/Bullets/PaintDecalManager.cpp
@@ -1,5 +1,35 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+#include "PaintDecalManager.h"
+#include "PaintDecal.h"
+#include "Engine/World.h"
 
+UPaintDecalManager* UPaintDecalManager::GetInstance(UWorld* World)
+{
+	if (!World) return nullptr;
 
-#include "Bullets/PaintDecalManager.h"
+	UGameInstance* GameInstance = World->GetGameInstance();
+	if (!GameInstance) return nullptr;
 
+	return GameInstance->GetSubsystem<UPaintDecalManager>();
+}
+
+void UPaintDecalManager::AddDecalList(APaintDecal* NewDecal)
+{
+	if (!NewDecal) return;
+
+	DecalList.Add(NewDecal);
+
+	DecalList.RemoveAll([](const TWeakObjectPtr<APaintDecal>& Decal)
+		{
+			return !Decal.IsValid();
+		});
+
+	// 월드에 배치된 데칼 개수가 최대값을 넘어갈 경우 가장 오래된 데칼 제거
+	if (DecalList.Num() > MaxDecal)
+	{
+		if (DecalList[0].IsValid())
+		{
+			DecalList[0]->Destroy();
+		}
+		DecalList.RemoveAt(0);
+	}
+}

--- a/Source/Splatoon/Bullets/PaintDecalManager.cpp
+++ b/Source/Splatoon/Bullets/PaintDecalManager.cpp
@@ -1,0 +1,5 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "Bullets/PaintDecalManager.h"
+

--- a/Source/Splatoon/Bullets/PaintDecalManager.h
+++ b/Source/Splatoon/Bullets/PaintDecalManager.h
@@ -1,0 +1,17 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/NoExportTypes.h"
+#include "PaintDecalManager.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class SPLATOON_API UPaintDecalManager : public UObject
+{
+	GENERATED_BODY()
+	
+};

--- a/Source/Splatoon/Bullets/PaintDecalManager.h
+++ b/Source/Splatoon/Bullets/PaintDecalManager.h
@@ -1,17 +1,24 @@
-// Fill out your copyright notice in the Description page of Project Settings.
-
 #pragma once
 
 #include "CoreMinimal.h"
-#include "UObject/NoExportTypes.h"
+#include "Subsystems/GameInstanceSubsystem.h"
 #include "PaintDecalManager.generated.h"
 
-/**
- * 
- */
+
+class APaintDecal;
+
 UCLASS()
-class SPLATOON_API UPaintDecalManager : public UObject
+class SPLATOON_API UPaintDecalManager : public UGameInstanceSubsystem
 {
 	GENERATED_BODY()
 	
+public:
+	static UPaintDecalManager* GetInstance(UWorld* World);
+	void AddDecalList(APaintDecal* NewDecal);
+
+private:
+	UPROPERTY()
+	TArray<TWeakObjectPtr<APaintDecal>> DecalList;
+	UPROPERTY(EditDefaultsOnly)
+	int32 MaxDecal = 50;
 };

--- a/Source/Splatoon/Bullets/StandardBullet.cpp
+++ b/Source/Splatoon/Bullets/StandardBullet.cpp
@@ -33,8 +33,6 @@ void AStandardBullet::BeginPlay()
 void AStandardBullet::OnHit(UPrimitiveComponent* HitComp, AActor* OtherActor, UPrimitiveComponent* OtherComp, FVector NormalImpulse, const FHitResult& Hit)
 {
 	Super::OnHit(HitComp, OtherActor, OtherComp, NormalImpulse, Hit);
-
-	GEngine->AddOnScreenDebugMessage(-1, 3.f, FColor::Red, FString::Printf(TEXT("OnHit")));
 }
 
 void AStandardBullet::OnBulletDestroyed()

--- a/Splatoon.uproject
+++ b/Splatoon.uproject
@@ -9,7 +9,8 @@
 			"Type": "Runtime",
 			"LoadingPhase": "Default",
 			"AdditionalDependencies": [
-				"Engine"
+				"Engine",
+				"CoreUObject"
 			]
 		}
 	],


### PR DESCRIPTION
 ## 📌 개요 
  - PaintDecalManager 클래스 생성

 ## 💻 작업사항 
  - 문제: Play 중단 후 다시 Play하면 탄환 충돌 시 크래시 발생
  - 해결 방법
    1. PaintDecalManager 클래스 생성: DecalList 관리 분리
    2. TWeakObjectPtr 사용
    3. PaintDecalManager를 GameInstanceSubsystem 상속받게 함

 ## 💡Issue 번호
 - close #22