### PR TITLE
[fix] 데칼 출력 수정 #56

### DIFF
--- a/Source/Splatoon/Bullets/BaseBullet.cpp
+++ b/Source/Splatoon/Bullets/BaseBullet.cpp
@@ -50,9 +50,9 @@ void ABaseBullet::OnHit(UPrimitiveComponent* HitComp, AActor* OtherActor, UPrimi
 		OnBulletDestroyed();
 		return;
 	}
-
+	
 	// PaintDecal 생성
-	APaintDecal::SpawnPaintDecal(GetWorld(), Hit.ImpactPoint, Hit.ImpactNormal.Rotation());
+	APaintDecal::SpawnPaintDecal(GetWorld(), Hit.ImpactPoint, (-Hit.ImpactNormal).Rotation());
 
 	OnBulletDestroyed();
 }


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력해 주세요.
  2. 명확하게 질문하고 명확하게 답변해 주세요.
 -->
 
 ## 📌 개요 
 <!-- PR내용에 대해 축약해서 적어주세요. -->
- 데칼 출력 수정

 ## 🐛 이슈
<!-- PR내용에 대해 상세 설명이 필요하다면 이 부분에 기재해 주세요. -->
- 데칼이 올바르게 출력되지 않는 부분 수정


## 🔧 해결 시도
<img src="https://github.com/user-attachments/assets/f8b85ebf-7d1c-4aa4-8cd9-de08dd79b239" width="40%">

1. 대략적인 콜리전 공부
2. 팀원들과 문제 해결 시 사용했던 변수 중 "ImpactNormal"를 떠올리게 됨

<br>

### 1차 시도 (ImpactPoint의 법선 벡터 방향으로 데칼 생성 시도)
``` C++
APaintDecal::SpawnPaintDecal(GetWorld(), Hit.ImpactPoint, (Hit.ImpactNormal).Rotation());
```
<img src="https://github.com/user-attachments/assets/7fa818b6-02ea-4fc8-b32c-ac950413a3a9" width="60%">

올바른 데칼 표시는 아니였으나 모두 반대로 표시됨을 확인하게 됨

<br>

### 결과 (반대 방향으로 데칼 생성 시도)
```C++
APaintDecal::SpawnPaintDecal(GetWorld(), Hit.ImpactPoint, (-Hit.ImpactNormal).Rotation());
```
<img src="https://github.com/user-attachments/assets/8ca3eaec-80ed-4d72-8e32-b34e0114e822" width="40%">
<img src="https://github.com/user-attachments/assets/383cb48e-a63f-4b5d-ad1c-cd0702c0bf57" width="35%">

<br><br>


## ❓ 궁금했던 부분
아래 두 코드의 차이
```C++
// A
APaintDecal::SpawnPaintDecal(GetWorld(), Hit.ImpactPoint, (-Hit.ImpactNormal).Rotation());
// B
APaintDecal::SpawnPaintDecal(GetWorld(), Hit.ImpactPoint, Hit.ImpactNormal.Rotation() * -1); 
```

- A코드는 항상 반대 회전을 보장 (방향을 바꾼 뒤 회전 값을 구하기에)
- B코드는 Pitch, Yaw 값이 90도 또는 -90도인 경우에만 반대를 보장 
<img src="https://github.com/user-attachments/assets/9b4e6048-f09f-4281-9417-21d367065c5c" width="30%">
<img src="https://github.com/user-attachments/assets/8acb540f-9c43-4e70-ba42-082c132b43b2" width="29%">


 ## 💡Issue 번호
<!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 - close #56 